### PR TITLE
Update chingu.gemspec

### DIFF
--- a/chingu.gemspec
+++ b/chingu.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]  
   s.rubyforge_project = "chingu"
 
-  s.add_dependency("gosu", [">= 0.7.45"])
   s.add_runtime_dependency("gosu", [">= 0.7.45"])
   s.add_development_dependency("rspec", [">= 2.1.0"])
   s.add_development_dependency("watchr", [">= 0"])


### PR DESCRIPTION
You have one or more invalid gemspecs that need to be fixed.
The gemspec at /home/user/.rvm/gems/ruby-2.3.0/bundler/gems/chingu-d3ed0ff0e0fa/chingu.gemspec is not valid. Please fix this gemspec.
The validation error was 'duplicate dependency on gosu (>= 0.7.45), (>= 0.7.45) use:
    add_runtime_dependency 'gosu', '>= 0.7.45', '>= 0.7.45'
